### PR TITLE
[Feat] #9 CS 주제의 답변에 댓글 등록 기능 추가

### DIFF
--- a/src/main/java/com/project/ity/api/cs/request/CsAnswerCommentRequest.java
+++ b/src/main/java/com/project/ity/api/cs/request/CsAnswerCommentRequest.java
@@ -1,0 +1,16 @@
+package com.project.ity.api.cs.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CsAnswerCommentRequest {
+
+    private Long id;
+
+    @NotBlank(message = "내용을 작성해주세요.")
+    private String comment;
+
+}

--- a/src/main/java/com/project/ity/api/cs/response/CsAnswerCommentResponse.java
+++ b/src/main/java/com/project/ity/api/cs/response/CsAnswerCommentResponse.java
@@ -1,0 +1,21 @@
+package com.project.ity.api.cs.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CsAnswerCommentResponse {
+    private Long id;
+
+    private String userId;
+
+    private String content;
+
+    public static CsAnswerCommentResponse of(Long id, String userId, String content) {
+        return new CsAnswerCommentResponse(id, userId, content);
+    }
+}

--- a/src/main/java/com/project/ity/domain/cs/dto/CsAnswerComment.java
+++ b/src/main/java/com/project/ity/domain/cs/dto/CsAnswerComment.java
@@ -1,0 +1,38 @@
+package com.project.ity.domain.cs.dto;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class CsAnswerComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userId;
+
+    private String comment;
+
+    @Column(nullable = false, updatable = false)
+    private String regDt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cs_answer_id")
+    private CsAnswer csAnswer;
+
+    @Builder
+    public CsAnswerComment(String userId, String comment, CsAnswer csAnswer) {
+        this.userId = userId;
+        this.comment = comment;
+        this.csAnswer = csAnswer;
+        this.regDt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    }
+}

--- a/src/main/java/com/project/ity/domain/cs/repository/CsAnswerCommentRepository.java
+++ b/src/main/java/com/project/ity/domain/cs/repository/CsAnswerCommentRepository.java
@@ -1,0 +1,11 @@
+package com.project.ity.domain.cs.repository;
+
+import com.project.ity.domain.cs.dto.CsAnswer;
+import com.project.ity.domain.cs.dto.CsAnswerComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CsAnswerCommentRepository extends JpaRepository<CsAnswerComment, Long> {
+    List<CsAnswerComment> findByCsAnswer(CsAnswer csAnswer);
+}

--- a/src/main/java/com/project/ity/domain/cs/service/CsAnswerCommentService.java
+++ b/src/main/java/com/project/ity/domain/cs/service/CsAnswerCommentService.java
@@ -1,0 +1,55 @@
+package com.project.ity.domain.cs.service;
+
+import com.project.ity.api.cs.request.CsAnswerCommentRequest;
+import com.project.ity.api.cs.response.CsAnswerCommentResponse;
+import com.project.ity.domain.cs.dto.CsAnswer;
+import com.project.ity.domain.cs.dto.CsAnswerComment;
+import com.project.ity.domain.cs.repository.CsAnswerRepository;
+import com.project.ity.domain.cs.repository.CsAnswerCommentRepository;
+import com.project.ity.global.exception.ErrorCode;
+import com.project.ity.global.exception.exceptions.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CsAnswerCommentService {
+    private final CsAnswerCommentRepository csAnswerCommentRepository;
+
+    private final CsAnswerRepository csAnswerRepository;
+
+    public List<CsAnswerCommentResponse> getCommentsByAnswerId(Long answerId) {
+        CsAnswer csAnswer = getCsAnswerById(answerId);
+
+        List<CsAnswerComment> comments = csAnswerCommentRepository.findByCsAnswer(csAnswer);
+
+        return comments.stream()
+                .map(comment -> CsAnswerCommentResponse.of(comment.getId(), comment.getUserId(), comment.getComment()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CsAnswerCommentResponse saveComment(CsAnswerCommentRequest request, String userId) {
+        CsAnswer csAnswer = getCsAnswerById(request.getId());
+
+        CsAnswerComment comment = CsAnswerComment.builder()
+                .userId(userId)
+                .comment(request.getComment())
+                .csAnswer(csAnswer)
+                .build();
+
+        csAnswerCommentRepository.save(comment);
+
+        return CsAnswerCommentResponse.of(comment.getId(), userId, comment.getComment());
+    }
+
+    private CsAnswer getCsAnswerById(Long answerId) {
+        return csAnswerRepository.findById(answerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_REGISTER_CS_TOPIC));
+    }
+}


### PR DESCRIPTION
Add comment registration logic for CS answers

## 🌿 문제

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 작업하게 된 배경을 간단히 적어주세요
1. 오늘의 CS 주제의 답변에 댓글을 등록하는 기능의 필요성

## 🌱 작업한 내용
- 작업한 내용을 작성합니다
1. 답변에 대한 댓글을 작성할 수 있는 PostController 추가

## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #
